### PR TITLE
Add launch and deploy helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,38 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Quick Start
+
+Use the provided helper scripts for common tasks.
+
+### Launch the dev server
+
+For Unix based systems run:
+
+```bash
+./launch.sh
+```
+
+For Windows PowerShell run:
+
+```powershell
+./launch.ps1
+```
+
+### Deploy to GitHub Pages
+
+For Unix based systems run:
+
+```bash
+./deploy.sh
+```
+
+For Windows PowerShell run:
+
+```powershell
+./deploy.ps1
+```
+
+These scripts will automatically install dependencies if needed before starting the server or deploying.
+

--- a/deploy.ps1
+++ b/deploy.ps1
@@ -1,0 +1,10 @@
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path 'node_modules')) {
+  Write-Host 'Installing dependencies...'
+  npm install
+}
+
+Write-Host 'Deploying to GitHub Pages...'
+npm run deploy
+

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+# Install dependencies if node_modules does not exist
+if [ ! -d node_modules ]; then
+  echo "Installing dependencies..."
+  npm install
+fi
+
+# Build and deploy to GitHub Pages
+npm run deploy
+

--- a/launch.ps1
+++ b/launch.ps1
@@ -1,0 +1,10 @@
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path 'node_modules')) {
+  Write-Host 'Installing dependencies...'
+  npm install
+}
+
+Write-Host 'Starting development server...'
+npm run dev
+

--- a/launch.sh
+++ b/launch.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+# Install dependencies if node_modules does not exist
+if [ ! -d node_modules ]; then
+  echo "Installing dependencies..."
+  npm install
+fi
+
+# Start the development server
+npm run dev
+


### PR DESCRIPTION
## Summary
- add helper scripts `launch.sh` and `deploy.sh`
- add Windows variants `launch.ps1` and `deploy.ps1`
- document quick start usage in `README`

## Testing
- `npm install`
- `npm run build`
- `npm run deploy` *(fails: Failed to get remote.origin.url)*

------
https://chatgpt.com/codex/tasks/task_e_685c00a7d9ac832e995f18f09e54acab