### PR TITLE
Add dark mode theme toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ If you are developing a production application, we recommend using TypeScript wi
 
 Use the provided helper scripts for common tasks.
 
+### Dark mode
+
+The navigation bar includes a theme toggle that switches between light and dark themes.
+Your preference is saved in `localStorage` and applied on page load. Users without a saved
+preference will default to their system color scheme.
+
 ### Launch the dev server
 
 For Unix based systems run:

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <meta name="description" content="Ryan Martinez AI Portfolio" />
     <title>Ryan Martinez</title>
   </head>
-  <body class="text-gray-900">
+  <body class="text-gray-900 dark:text-gray-100">
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,48 +1,51 @@
 import React from "react";
 import { Link, useLocation } from "react-router-dom";
 import shyguyryicon from "../assets/shyguyry_icon.png";
+import ThemeToggle from "./ThemeToggle";
 
 export default function Navbar() {
   const location = useLocation();
 
   return (
-    <header className="fixed top-0 left-0 w-full bg-white shadow z-50">
+    <header className="fixed top-0 left-0 w-full bg-white dark:bg-gray-900 shadow z-50">
       <nav className="max-w-6xl mx-auto flex items-center justify-between px-6 py-4">
         <div className="text-lg font-bold flex items-center gap-2">
           <img src={shyguyryicon} alt="Icon" className="w-6 h-6" />
           <Link to="/">Ryan Martinez</Link>
         </div>
-        <ul className="flex space-x-6 text-sm text-gray-700">
-          <li>
-            <Link to="/" className="hover:text-blue-600 transition">
-              Home
-            </Link>
-          </li>
-          <li>
-            <Link
-              to="/agents"
-              className={`hover:text-blue-600 transition ${location.pathname.startsWith("/agents") ? "font-semibold underline" : ""}`}
-            >
-              Agents
-            </Link>
-          </li>
-          <li>
-            <Link to="/contact" className="hover:text-blue-600 transition">
-              Contact
-            </Link>
-          </li>
-                  <li>
-  <Link
-    to="/blog"
-    className={`hover:text-blue-600 transition ${
-      location.pathname.startsWith("/blog") ? "font-semibold underline" : ""
-    }`}
-  >
-    Blog
-  </Link>
-</li>
-        </ul>
-
+        <div className="flex items-center space-x-4">
+          <ul className="flex space-x-6 text-sm text-gray-700 dark:text-gray-200">
+            <li>
+              <Link to="/" className="hover:text-blue-600 transition">
+                Home
+              </Link>
+            </li>
+            <li>
+              <Link
+                to="/agents"
+                className={`hover:text-blue-600 transition ${location.pathname.startsWith("/agents") ? "font-semibold underline" : ""}`}
+              >
+                Agents
+              </Link>
+            </li>
+            <li>
+              <Link to="/contact" className="hover:text-blue-600 transition">
+                Contact
+              </Link>
+            </li>
+            <li>
+              <Link
+                to="/blog"
+                className={`hover:text-blue-600 transition ${
+                  location.pathname.startsWith("/blog") ? "font-semibold underline" : ""
+                }`}
+              >
+                Blog
+              </Link>
+            </li>
+          </ul>
+          <ThemeToggle />
+        </div>
       </nav>
     </header>
   );

--- a/src/components/ThemeToggle.jsx
+++ b/src/components/ThemeToggle.jsx
@@ -1,0 +1,31 @@
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "../contexts/ThemeContext";
+
+export default function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+
+  const resolvedTheme =
+    theme === "system"
+      ? window.matchMedia("(prefers-color-scheme: dark)").matches
+        ? "dark"
+        : "light"
+      : theme;
+
+  const toggle = () => {
+    setTheme(resolvedTheme === "dark" ? "light" : "dark");
+  };
+
+  return (
+    <button
+      aria-label="Toggle theme"
+      onClick={toggle}
+      className="p-2 rounded-full bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600"
+    >
+      {resolvedTheme === "dark" ? (
+        <Sun className="w-4 h-4 text-yellow-300" />
+      ) : (
+        <Moon className="w-4 h-4 text-gray-800" />
+      )}
+    </button>
+  );
+}

--- a/src/contexts/ThemeContext.jsx
+++ b/src/contexts/ThemeContext.jsx
@@ -1,0 +1,43 @@
+import { createContext, useContext, useEffect, useState } from "react";
+
+const ThemeContext = createContext({
+  theme: "system",
+  setTheme: () => {},
+});
+
+export const ThemeProvider = ({ children }) => {
+  const [theme, setTheme] = useState("system");
+
+  useEffect(() => {
+    const stored = localStorage.getItem("theme");
+    if (stored === "light" || stored === "dark" || stored === "system") {
+      setTheme(stored);
+    }
+  }, []);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const resolvedTheme =
+      theme === "system"
+        ? window.matchMedia("(prefers-color-scheme: dark)").matches
+          ? "dark"
+          : "light"
+        : theme;
+
+    if (resolvedTheme === "dark") {
+      root.classList.add("dark");
+    } else {
+      root.classList.remove("dark");
+    }
+
+    localStorage.setItem("theme", theme);
+  }, [theme]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => useContext(ThemeContext);

--- a/src/index.css
+++ b/src/index.css
@@ -9,3 +9,8 @@ body {
   background-attachment: fixed;
   transition: background 0.1s ease-out;
 }
+
+html.dark body {
+  background: radial-gradient(circle at var(--mouse-x, 50%) var(--mouse-y, 50%),
+      #0f172a, #1e293b, #334155, #475569);
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css'; // ✅ Tailwind import
 import HomePage from './App';
+import { ThemeProvider } from './contexts/ThemeContext';
 
 // Track mouse position to update gradient background
 document.addEventListener('mousemove', (e) => {
@@ -11,8 +12,10 @@ document.addEventListener('mousemove', (e) => {
   document.documentElement.style.setProperty('--mouse-y', `${y}px`);
 });
 
-ReactDOM.createRoot(document.getElementById('root')).render(
+ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <HomePage />
+    <ThemeProvider>
+      <HomePage />
+    </ThemeProvider>
   </React.StrictMode>
 );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,9 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: [
-    "./index.html",
-    "./src/**/*.{js,jsx}"
+    './index.html',
+    './src/**/*.{js,jsx}'
   ],
   theme: {
     extend: {},


### PR DESCRIPTION
## Summary
- implement ThemeProvider for theme persistence
- add ThemeToggle button to navbar
- support Tailwind dark mode and global dark theme gradient
- document dark mode usage in README

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685c0c5facc0832ebc38029d24dc6aa1