### PR TITLE
Add RSS feed generation

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <link rel="icon" type="image/png" href="/favicon.png" />
+    <link rel="alternate" type="application/rss+xml" href="/rss.xml" title="RSS Feed" />
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Ryan Martinez AI Portfolio" />

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "prebuild": "node scripts/generateRss.mjs",
     "build": "vite build",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d dist"

--- a/public/rss.xml
+++ b/public/rss.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+<channel>
+  <title>Ryan Martinez Blog</title>
+  <link>https://shyguyrymakesai.github.io</link>
+  <description>Latest posts from Ryan Martinez</description>
+  <item>
+    <title>So I Say Yes</title>
+    <link>https://shyguyrymakesai.github.io/#/blog/1</link>
+    <guid>https://shyguyrymakesai.github.io/#/blog/1</guid>
+    <description>One of my favorite poems I've ever written for meg, or myself for that matter.</description>
+  </item>
+  <item>
+    <title>Second Spark</title>
+    <link>https://shyguyrymakesai.github.io/#/blog/4</link>
+    <guid>https://shyguyrymakesai.github.io/#/blog/4</guid>
+    <description>A short meditation on humanity, AI, and the luminous edge of what's to come.</description>
+  </item>
+  <item>
+    <title>Welcome to the Future</title>
+    <link>https://shyguyrymakesai.github.io/#/blog/2</link>
+    <guid>https://shyguyrymakesai.github.io/#/blog/2</guid>
+    <description>Follow me into the matrix as I build the future.</description>
+  </item>
+  <item>
+    <title>Existential Sirens</title>
+    <link>https://shyguyrymakesai.github.io/#/blog/5</link>
+    <guid>https://shyguyrymakesai.github.io/#/blog/5</guid>
+    <description>A reflection on existence and hidden OCD.</description>
+  </item>
+  <item>
+    <title>Forward March</title>
+    <link>https://shyguyrymakesai.github.io/#/blog/6</link>
+    <guid>https://shyguyrymakesai.github.io/#/blog/6</guid>
+    <description>Persevering through the maze of life without looking back.</description>
+  </item>
+  <item>
+    <title>Devil's Bargain</title>
+    <link>https://shyguyrymakesai.github.io/#/blog/7</link>
+    <guid>https://shyguyrymakesai.github.io/#/blog/7</guid>
+    <description>Grieving the cost of an ascent that fused two beings.</description>
+  </item>
+  <item>
+    <title>Banjo's Question</title>
+    <link>https://shyguyrymakesai.github.io/#/blog/8</link>
+    <guid>https://shyguyrymakesai.github.io/#/blog/8</guid>
+    <description>Exploring meaning in repeated rhythms.</description>
+  </item>
+  <item>
+    <title>Eyes in the Abyss</title>
+    <link>https://shyguyrymakesai.github.io/#/blog/9</link>
+    <guid>https://shyguyrymakesai.github.io/#/blog/9</guid>
+    <description>Meeting the void and its silent watchers.</description>
+  </item>
+  <item>
+    <title>Pinker Pastures</title>
+    <link>https://shyguyrymakesai.github.io/#/blog/10</link>
+    <guid>https://shyguyrymakesai.github.io/#/blog/10</guid>
+    <description>Loving all hues of life, even cotton candy fields.</description>
+  </item>
+</channel>
+</rss>

--- a/scripts/generateRss.mjs
+++ b/scripts/generateRss.mjs
@@ -1,0 +1,21 @@
+import fs from 'fs';
+import { fakePosts } from '../src/data/posts.js';
+
+const siteUrl = 'https://shyguyrymakesai.github.io';
+
+function escape(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+const items = fakePosts.map(post => {
+  const link = `${siteUrl}/#/blog/${post.id}`;
+  return `  <item>\n    <title>${escape(post.title)}</title>\n    <link>${link}</link>\n    <guid>${link}</guid>\n    <description>${escape(post.snippet)}</description>\n  </item>`;
+}).join('\n');
+
+const rss = `<?xml version="1.0" encoding="UTF-8"?>\n<rss version="2.0">\n<channel>\n  <title>Ryan Martinez Blog</title>\n  <link>${siteUrl}</link>\n  <description>Latest posts from Ryan Martinez</description>\n${items}\n</channel>\n</rss>`;
+
+fs.writeFileSync('./public/rss.xml', rss);
+console.log('RSS feed generated');


### PR DESCRIPTION
## Summary
- generate rss.xml from blog posts
- run generator before every build
- link RSS feed from index.html

## Testing
- `node scripts/generateRss.mjs`
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685c0db99788832e9cb9cc4cf9ee8f4d