### PR TITLE
Refine dark mode palette

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -7,7 +7,7 @@ export default function Navbar() {
   const location = useLocation();
 
   return (
-    <header className="fixed top-0 left-0 w-full bg-white dark:bg-gray-900 shadow z-50">
+    <header className="fixed top-0 left-0 w-full bg-white dark:bg-gray-800 shadow z-50">
       <nav className="max-w-6xl mx-auto flex items-center justify-between px-6 py-4">
         <div className="text-lg font-bold flex items-center gap-2">
           <img src={shyguyryicon} alt="Icon" className="w-6 h-6" />

--- a/src/components/ThemeToggle.jsx
+++ b/src/components/ThemeToggle.jsx
@@ -19,7 +19,7 @@ export default function ThemeToggle() {
     <button
       aria-label="Toggle theme"
       onClick={toggle}
-      className="p-2 rounded-full bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600"
+      className="p-2 rounded-full bg-gray-200 hover:bg-gray-300 dark:bg-gray-600 dark:hover:bg-gray-500"
     >
       {resolvedTheme === "dark" ? (
         <Sun className="w-4 h-4 text-yellow-300" />

--- a/src/index.css
+++ b/src/index.css
@@ -11,6 +11,11 @@ body {
 }
 
 html.dark body {
-  background: radial-gradient(circle at var(--mouse-x, 50%) var(--mouse-y, 50%),
-      #0f172a, #1e293b, #334155, #475569);
+  background: radial-gradient(
+      circle at var(--mouse-x, 50%) var(--mouse-y, 50%),
+      #1f2937,
+      #374151,
+      #4b5563,
+      #6b7280
+  );
 }

--- a/src/pages/AgentProfile.jsx
+++ b/src/pages/AgentProfile.jsx
@@ -22,12 +22,12 @@ export default function AgentProfile() {
   }
 
   return (
-    <main className="min-h-screen font-sans bg-white">
+    <main className="min-h-screen font-sans bg-white dark:bg-gray-900">
       <Navbar />
 
       {/* Responsive Hero Banner */}
       {agent.banner && (
-        <section className="relative w-full bg-white overflow-hidden">
+        <section className="relative w-full bg-white dark:bg-gray-800 overflow-hidden">
           <div className="w-full max-h-[420px] sm:max-h-[480px] md:max-h-[520px] overflow-hidden">
             <img
               src={agent.banner}
@@ -58,7 +58,7 @@ export default function AgentProfile() {
               {agent.capabilities.map((cap, idx) => (
                 <li
                   key={idx}
-                  className={`bg-white ${agent.themeColor?.border || "border-gray-200"} px-4 py-3 rounded-lg shadow-sm hover:shadow-md transition`}
+                  className={`bg-white dark:bg-gray-800 ${agent.themeColor?.border || "border-gray-200"} px-4 py-3 rounded-lg shadow-sm hover:shadow-md transition`}
                 >
                   ✅ {cap}
                 </li>

--- a/src/pages/AgentsPage.jsx
+++ b/src/pages/AgentsPage.jsx
@@ -8,13 +8,13 @@ export default function AgentsPage() {
   const isHome = location.pathname === "/";
 
   return (
-    <main className="min-h-screen font-sans bg-white scroll-smooth">
+    <main className="min-h-screen font-sans bg-white dark:bg-gray-900 scroll-smooth">
             <Navbar />
       
       {/* Top Navigation Bar */}
 
       {/* Hero Banner */}
-      <section className="relative bg-gradient-to-r from-blue-50 to-blue-100 pt-32 pb-20 text-center px-6 overflow-hidden">
+      <section className="relative bg-gradient-to-r from-blue-50 to-blue-100 dark:from-gray-700 dark:to-gray-800 pt-32 pb-20 text-center px-6 overflow-hidden">
         <div className="absolute inset-0 opacity-10 animate-pulse bg-[url('/grid.svg')] bg-center bg-cover pointer-events-none" />
         <div className="max-w-3xl mx-auto relative z-10">
           <h1 className="text-5xl font-bold mb-4 text-blue-800">Meet the Agents 🤖</h1>
@@ -29,7 +29,7 @@ export default function AgentsPage() {
       {agents.map((agent, index) => (
         <section
           key={agent.id}
-          className={`py-16 px-6 bg-gradient-to-br ${agent.themeGradient} scroll-mt-20 animate-fade-in`}
+          className={`py-16 px-6 bg-gradient-to-br ${agent.themeGradient} dark:from-gray-800 dark:to-gray-900 scroll-mt-20 animate-fade-in`}
         >
           <div
             className={`max-w-6xl mx-auto flex flex-col ${
@@ -61,7 +61,7 @@ export default function AgentsPage() {
       ))}
 
       {/* CTA Footer */}
-      <section className="bg-gray-100 py-12 px-6 text-center relative overflow-hidden">
+      <section className="bg-gray-100 dark:bg-gray-800 py-12 px-6 text-center relative overflow-hidden">
         <div className="absolute inset-0 bg-gradient-to-br from-blue-100 to-blue-200 opacity-10 animate-fade-in pointer-events-none" />
         <div className="relative z-10">
           <h3 className="text-xl font-semibold mb-2">Want a custom agent for your business?</h3>

--- a/src/pages/Blog.jsx
+++ b/src/pages/Blog.jsx
@@ -62,7 +62,7 @@ export default function Blog() {
   const [searchTerm, setSearchTerm] = useState("");
 
   return (
-    <div className="relative overflow-hidden min-h-screen py-16 px-6 bg-gradient-to-b from-[#1a102a] to-black">
+    <div className="relative overflow-hidden min-h-screen py-16 px-6 bg-gradient-to-b from-[#1a102a] to-black dark:from-gray-800 dark:to-gray-900">
       <style>{`
         @keyframes midnightPulse {
           0%, 100% { background-position: 0% 50%; }
@@ -164,7 +164,7 @@ export default function Blog() {
             setRandomPost(pick);
             navigate(`/blog/${pick.id}`);
           }}
-          className="px-6 py-3 text-sm font-semibold rounded-full shadow-md bg-white text-black hover:text-transparent hover:bg-gradient-to-r hover:from-fuchsia-500 hover:to-cyan-400 hover:bg-clip-text transition-all duration-300"
+          className="px-6 py-3 text-sm font-semibold rounded-full shadow-md bg-white dark:bg-gray-700 text-black dark:text-white hover:text-transparent hover:bg-gradient-to-r hover:from-fuchsia-500 hover:to-cyan-400 hover:bg-clip-text transition-all duration-300"
         >
           🎲 Surprise Me
         </button>

--- a/src/pages/BlogEntryPage.jsx
+++ b/src/pages/BlogEntryPage.jsx
@@ -19,7 +19,7 @@ export default function BlogEntryPage() {
   }
 
   return (
-    <div className="relative min-h-screen px-6 py-16 bg-gradient-to-b from-[#1a102a] to-black text-white overflow-hidden">
+    <div className="relative min-h-screen px-6 py-16 bg-gradient-to-b from-[#1a102a] to-black dark:from-gray-800 dark:to-gray-900 text-white overflow-hidden">
       <SparklesCore className="absolute inset-0 -z-10 opacity-40" />
 
       <Link

--- a/src/pages/ContactPage.jsx
+++ b/src/pages/ContactPage.jsx
@@ -42,7 +42,7 @@ export default function ContactPage() {
   };
 
   return (
-    <main className="relative min-h-screen font-sans bg-gradient-to-b from-emerald-100 to-emerald-200 overflow-hidden">
+    <main className="relative min-h-screen font-sans bg-gradient-to-b from-emerald-100 to-emerald-200 dark:from-gray-800 dark:to-gray-900 overflow-hidden">
       <Navbar />
       <SparklesCore className="absolute inset-0 -z-10 opacity-40" />
       <Toaster position="top-center" reverseOrder={false} />
@@ -73,7 +73,7 @@ export default function ContactPage() {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.2, duration: 0.6 }}
-          className="w-full max-w-md bg-white/70 backdrop-blur-md border border-emerald-200 rounded-xl shadow-xl p-8"
+          className="w-full max-w-md bg-white/70 dark:bg-gray-800/60 backdrop-blur-md border border-emerald-200 dark:border-gray-700 rounded-xl shadow-xl p-8"
         >
           <form onSubmit={handleSubmit} className="space-y-6">
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -127,7 +127,7 @@ export default function ContactPage() {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.4, duration: 0.6 }}
-          className="w-full max-w-md bg-white/70 backdrop-blur-md border border-emerald-200 rounded-xl shadow-xl p-8 space-y-4"
+          className="w-full max-w-md bg-white/70 dark:bg-gray-800/60 backdrop-blur-md border border-emerald-200 dark:border-gray-700 rounded-xl shadow-xl p-8 space-y-4"
         >
           <h2 className="text-2xl font-bold text-green-900 text-center">Prefer direct contact?</h2>
           <div className="flex items-center gap-3 text-gray-700">

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -22,7 +22,7 @@ export default function HomePage() {
   });
 
   return (
-    <main className="min-h-screen font-sans scroll-smooth">
+    <main className="min-h-screen font-sans scroll-smooth bg-white dark:bg-gray-900">
       <Navbar />
 
       <div className="pt-24">
@@ -31,7 +31,7 @@ export default function HomePage() {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.8 }}
-          className="relative bg-white py-32 px-6 text-center overflow-hidden"
+          className="relative bg-white dark:bg-gray-800 py-32 px-6 text-center overflow-hidden"
         >
           <SparklesCore className="absolute inset-0 -z-10 opacity-30" />
           <img
@@ -54,7 +54,7 @@ export default function HomePage() {
         {/* Project Section */}
         <motion.section
           id="project"
-          className="bg-gray-100 py-14 px-6"
+          className="bg-gray-100 dark:bg-gray-800 py-14 px-6"
           initial={{ opacity: 0, y: 50 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
@@ -62,7 +62,7 @@ export default function HomePage() {
         >
           <h2 className="text-3xl font-bold text-center mb-10">Featured Projects</h2>
           <div className="max-w-5xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-10 items-center">
-            <Link to="/projects/ai-assistant" className="rounded-xl overflow-hidden shadow-lg border bg-white block">
+            <Link to="/projects/ai-assistant" className="rounded-xl overflow-hidden shadow-lg border bg-white dark:bg-gray-700 block">
               <img
                 src={demoImage}
                 alt="AI Assistant Demo"
@@ -79,7 +79,7 @@ export default function HomePage() {
                 {['LangChain', 'FastAPI', 'Tool Routing', 'Memory', 'Docker'].map((tag) => (
                   <li
                     key={tag}
-                    className="bg-white px-3 py-1 rounded-full shadow-sm border hover:bg-blue-50 hover:text-blue-700 transition"
+                    className="bg-white dark:bg-gray-700 px-3 py-1 rounded-full shadow-sm border hover:bg-blue-50 dark:hover:bg-gray-600 hover:text-blue-700 dark:text-gray-200 dark:hover:text-blue-300 transition"
                   >
                     {tag}
                   </li>
@@ -100,7 +100,7 @@ export default function HomePage() {
         {/* About Me Section */}
         <motion.section
           id="about"
-          className="bg-white py-20 px-6 text-center"
+          className="bg-white dark:bg-gray-800 py-20 px-6 text-center"
           initial={{ opacity: 0, y: 50 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
@@ -117,7 +117,7 @@ export default function HomePage() {
         {/* Resume Section */}
         <motion.section
           id="resume"
-          className="bg-gray-50 py-20 px-6"
+          className="bg-gray-50 dark:bg-gray-700 py-20 px-6"
           initial={{ opacity: 0, y: 50 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
@@ -183,7 +183,7 @@ export default function HomePage() {
         {/* Contact Section */}
         <motion.footer
           id="contact"
-          className="bg-gray-100 py-16 px-6 text-center text-sm text-gray-600"
+          className="bg-gray-100 dark:bg-gray-800 py-16 px-6 text-center text-sm text-gray-600 dark:text-gray-300"
           initial={{ opacity: 0 }}
           whileInView={{ opacity: 1 }}
           viewport={{ once: true }}


### PR DESCRIPTION
## Summary
- soften radial gradient for dark mode
- adjust navbar and toggle colors
- update pages to use deeper gray backgrounds when dark mode is active

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685c0eb77528832ebd3580544e204ef3