### PR TITLE
Fix blog markdown rendering and comment id

### DIFF
--- a/src/pages/Blog.jsx
+++ b/src/pages/Blog.jsx
@@ -45,7 +45,7 @@ export const BlogCard = ({ post }) => {
                 exit={{ height: 0, opacity: 0 }}
                 className="mt-2 text-xs text-gray-300 overflow-hidden line-clamp-2 prose prose-invert prose-p:m-0 prose-p:leading-snug"
               >
-                <ReactMarkdown>{post.full}</ReactMarkdown>
+                <ReactMarkdown>{post.content}</ReactMarkdown>
               </motion.div>
             )}
           </AnimatePresence>

--- a/src/pages/BlogEntryPage.jsx
+++ b/src/pages/BlogEntryPage.jsx
@@ -49,10 +49,10 @@ export default function BlogEntryPage() {
           transition={{ duration: 0.6 }}
           className="mt-6 prose prose-invert prose-p:text-gray-200 prose-strong:text-white prose-a:text-pink-300"
         >
-          <ReactMarkdown>{post.full}</ReactMarkdown>
+          <ReactMarkdown>{post.content}</ReactMarkdown>
         </motion.div>
 
-        <CommentBox postId={post.id} />
+        <CommentBox postId={post.slug} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- render markdown from `post.content`
- pass the slug to `CommentBox` so comments attach correctly

## Testing
- `npm test` *(fails: missing Prisma database)*

------
https://chatgpt.com/codex/tasks/task_e_685c14f79cbc832e88a90be8094b2620