### PR TITLE
Improve dark mode colors

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -5,7 +5,7 @@
 body {
   min-height: 100vh;
   background: radial-gradient(circle at var(--mouse-x, 50%) var(--mouse-y, 50%),
-      #ff66ff, #a855f7, #6366f1, #3b82f6);
+      #dc8a78, #ea76cb, #8839ef, #1e66f5);
   background-attachment: fixed;
   transition: background 0.1s ease-out;
 }
@@ -13,9 +13,10 @@ body {
 html.dark body {
   background: radial-gradient(
       circle at var(--mouse-x, 50%) var(--mouse-y, 50%),
-      #1e1b4b,
-      #312e81,
-      #4c1d95,
-      #6d28d9
+      #f2e9f3,
+      #e9d5ec,
+      #d8bee2,
+      #c9a4d9
   );
+  color: #000 !important;
 }


### PR DESCRIPTION
## Summary
- update page gradients to use a pastel color palette
- force dark mode text color to black for better legibility

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_685c5733c704832ebf9958d12abed764