### PR TITLE
Add FlameCoin highlight page

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ MDX files in `src/data/projects` define each portfolio item. They export a
 and `repo` links. Visiting `/#/projects/:slug` renders a page with a gallery and
 syntax-highlighted snippets.
 
+The site now also includes a highlight page for the **FlameCoin** experiment at
+`/flamecoin`. It showcases the genesis soulbound token and links to the
+contract metadata.
+
 
 ## Booking System
 

--- a/components/FlameHero.tsx
+++ b/components/FlameHero.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import styles from '../styles/flamecoin.module.css';
+
+export default function FlameHero() {
+  return (
+    <section className={styles.hero}>
+      <h1 className={styles.heroTitle}>FlameCoin</h1>
+      <p className={styles.heroSubtitle}>
+        Soulbound tokens minted by agents, for memory and meaning
+      </p>
+    </section>
+  );
+}

--- a/components/GenesisCard.tsx
+++ b/components/GenesisCard.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import styles from '../styles/flamecoin.module.css';
+import tokenImg from '../src/assets/1.png';
+
+export default function GenesisCard() {
+  return (
+    <div className={styles.card}>
+      <img src={tokenImg} alt="FlameCoin #1" className={styles.cardImage} />
+      <h3 className={styles.cardTitle}>Genesis Token #1</h3>
+      <p className={styles.cardOwner}>Owner: Ryan (0xbdfe...3ae)</p>
+      <p>
+        <a
+          href="/metadata/1"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={styles.cardLink}
+        >
+          Metadata
+        </a>
+        {' '}|{' '}
+        <a
+          href="https://sepolia.scrollscan.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={styles.cardLink}
+        >
+          View on Explorer
+        </a>
+      </p>
+    </div>
+  );
+}

--- a/pages/flamecoin.tsx
+++ b/pages/flamecoin.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import FlameHero from '../components/FlameHero';
+import GenesisCard from '../components/GenesisCard';
+import styles from '../styles/flamecoin.module.css';
+
+export default function FlameCoinPage() {
+  return (
+    <main className={styles.page}>
+      <FlameHero />
+
+      <section className={styles.section}>
+        <h2>What is FlameCoin?</h2>
+        <p>
+          FlameCoin is an experiment in soulbound tokens. Autonomous agents sign
+          messages that are checked by on-chain logic before minting on Scroll
+          Sepolia.
+        </p>
+        <ul>
+          <li>Soulbound identity and history</li>
+          <li>AI agents provide logic-gated signatures</li>
+          <li>Deployed on Scroll Sepolia</li>
+        </ul>
+      </section>
+
+      <section className={styles.section}>
+        <h2>Genesis Token</h2>
+        <GenesisCard />
+      </section>
+
+      <section className={styles.section}>
+        <h2>Minting Process</h2>
+        <p>Agent → Signature → Reason → Mint (reverse Turing test)</p>
+      </section>
+
+      <section className={styles.vision}>
+        <p>"A coin of fire, forged in logic."</p>
+        <p>"Proof of being, not just belonging."</p>
+      </section>
+
+      <section className={styles.actions}>
+        <a
+          href="https://github.com/shyguyrymakesai/flamecoin"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={styles.button}
+        >
+          Explore the Code
+        </a>
+      </section>
+    </main>
+  );
+}

--- a/styles/flamecoin.module.css
+++ b/styles/flamecoin.module.css
@@ -1,0 +1,65 @@
+.page {
+  min-height: 100vh;
+  background-color: #0c0c0c;
+  color: #f3f4f6;
+  font-family: sans-serif;
+}
+.hero {
+  padding: 4rem 1rem;
+  background: radial-gradient(circle, rgba(255,94,0,0.6), transparent 70%);
+  text-align: center;
+}
+.heroTitle {
+  font-size: 3rem;
+  font-weight: 800;
+  margin-bottom: 1rem;
+}
+.heroSubtitle {
+  font-size: 1.25rem;
+}
+.section {
+  padding: 2rem 1rem;
+  max-width: 800px;
+  margin: 0 auto;
+}
+.card {
+  background: rgba(255,255,255,0.1);
+  padding: 1.5rem;
+  border-radius: 0.75rem;
+  text-align: center;
+}
+.cardImage {
+  width: 200px;
+  height: auto;
+  border-radius: 0.5rem;
+  margin-bottom: 1rem;
+}
+.cardTitle {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+.cardOwner {
+  margin-bottom: 0.5rem;
+}
+.cardLink {
+  color: #3b82f6;
+  text-decoration: underline;
+}
+.vision {
+  font-family: Georgia, serif;
+  text-align: center;
+  padding: 3rem 1rem;
+  font-size: 1.25rem;
+}
+.actions {
+  text-align: center;
+  padding-bottom: 4rem;
+}
+.button {
+  background: #ea580c;
+  color: #fff;
+  padding: 0.75rem 1.5rem;
+  border-radius: 0.375rem;
+  text-decoration: none;
+}


### PR DESCRIPTION
## Summary
- create FlameHero and GenesisCard components
- implement `/flamecoin` page
- add FlameCoin styles
- document the new page in the README

## Testing
- `npm test --silent` *(fails: Tag CRUD test due to missing database)*

------
https://chatgpt.com/codex/tasks/task_e_685c5ed7d488832e962d226d20b54e75