### PR TITLE
Link genesis token to Scroll explorer

### DIFF
--- a/components/GenesisCard.tsx
+++ b/components/GenesisCard.tsx
@@ -1,13 +1,30 @@
 import React from 'react';
 import styles from '../styles/flamecoin.module.css';
-import tokenImg from '../src/assets/1.png';
+// Replace the local asset with the IPFS-hosted image for the genesis token
 
 export default function GenesisCard() {
   return (
-    <div className={styles.card}>
-      <img src={tokenImg} alt="FlameCoin #1" className={styles.cardImage} />
-      <h3 className={styles.cardTitle}>Genesis Token #1</h3>
+    <div
+      className={styles.card}
+      data-name="FlameCoin – Indigo-Cinnabar Rose"
+      data-description="The inaugural Soulbound FlameCoin depicting a rose whose petals fade from deep indigo to cinnabar red – an eternal symbol of prophecy and rebirth."
+      data-image="ipfs://bafybeihrgad3lx4c5lid6vczbfmv6ytkrgfesjydffys4obdx6tp36dqem"
+      data-primary-hue="Indigo"
+      data-secondary-hue="Cinnabar Red"
+      data-flower="Rose"
+      data-genesis="true"
+    >
+      <img
+        src="https://ipfs.io/ipfs/bafybeihrgad3lx4c5lid6vczbfmv6ytkrgfesjydffys4obdx6tp36dqem"
+        alt="FlameCoin – Indigo-Cinnabar Rose"
+        className={styles.cardImage}
+      />
+      <h3 className={styles.cardTitle}>FlameCoin – Indigo-Cinnabar Rose</h3>
       <p className={styles.cardOwner}>Owner: Ryan (0xbdfe...3ae)</p>
+      <p className={styles.cardDescription}>
+        The inaugural Soulbound FlameCoin depicting a rose whose petals fade from
+        deep indigo to cinnabar red – an eternal symbol of prophecy and rebirth.
+      </p>
       <p>
         <a
           href="/metadata/1"
@@ -19,12 +36,12 @@ export default function GenesisCard() {
         </a>
         {' '}|{' '}
         <a
-          href="https://sepolia.scrollscan.com/"
+          href="https://sepolia.scrollscan.com/tx/0x9b8c3b3d40d6110eed6ca1c09927cd32119be1a5688cbc8c76bbbd6168d575cd"
           target="_blank"
           rel="noopener noreferrer"
           className={styles.cardLink}
         >
-          View on Explorer
+          View on Scroll
         </a>
       </p>
     </div>

--- a/styles/flamecoin.module.css
+++ b/styles/flamecoin.module.css
@@ -42,6 +42,9 @@
 .cardOwner {
   margin-bottom: 0.5rem;
 }
+.cardDescription {
+  margin-bottom: 0.5rem;
+}
 .cardLink {
   color: #3b82f6;
   text-decoration: underline;


### PR DESCRIPTION
## Summary
- display the IPFS hosted image on the Genesis card
- expose token metadata in `data-*` attributes
- add a description line and link the mint tx on Scroll

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_685c831a0588832eb1379bef9a922d22