### PR TITLE
Fix Kame gallery rendering

### DIFF
--- a/components/KameGallery.jsx
+++ b/components/KameGallery.jsx
@@ -1,0 +1,108 @@
+import React, { useEffect, useState } from 'react';
+import { ethers } from 'ethers';
+import styles from '../styles/kamestyle.module.css';
+
+const ABI = [
+  'function tokenURI(uint256 tokenId) view returns (string)',
+  'event Transfer(address indexed from, address indexed to, uint256 indexed tokenId)'
+];
+
+const CONTRACT_ADDRESS = '0x0820858CdF14c92a7105dA6f0fB4218454683f76';
+const RPC_URL = import.meta.env.VITE_SCROLL_SEPOLIA_RPC || 'https://sepolia-rpc.scroll.io/';
+
+function ipfsToHttp(url) {
+  if (!url) return '';
+  return url.startsWith('ipfs://') ? url.replace('ipfs://', 'https://ipfs.io/ipfs/') : url;
+}
+
+export default function KameGallery() {
+  const [tokens, setTokens] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    async function fetchTokens() {
+      try {
+        const provider = new ethers.JsonRpcProvider(RPC_URL);
+        const contract = new ethers.Contract(CONTRACT_ADDRESS, ABI, provider);
+        const events = await contract.queryFilter(contract.filters.Transfer(), 0, 'latest');
+        const ids = Array.from(new Set(events.map(ev => ev.args?.tokenId.toString())));
+        const metas = await Promise.all(ids.map(async id => {
+          try {
+            const uri = await contract.tokenURI(id);
+            const res = await fetch(ipfsToHttp(uri));
+            const meta = await res.json();
+            return { id, meta: { ...meta, image: ipfsToHttp(meta.image) } };
+          } catch (err) {
+            console.error(`Error fetching token ${id}`, err);
+            return null;
+          }
+        }));
+        setTokens(metas.filter(Boolean));
+      } catch (err) {
+        console.error('Error loading tokens', err);
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchTokens();
+  }, []);
+
+  const prev = () => setIndex((index - 1 + tokens.length) % tokens.length);
+  const next = () => setIndex((index + 1) % tokens.length);
+
+  if (loading) return <p className={styles.section}>Loading gallery...</p>;
+  if (!tokens.length) {
+    return (
+      <section className={styles.section}>
+        <p>No glyphs minted yet.</p>
+        <a href="/" className={styles.homeButton}>Return Home</a>
+      </section>
+    );
+  }
+
+  const EXPLORER_URL = `https://sepolia.etherscan.io/token/${CONTRACT_ADDRESS}?a=${tokens[index].id}`;
+
+  return (
+    <section className={styles.section}>
+      <h2>Minted Glyphs</h2>
+      <div className={styles.carousel} style={{ justifyContent: 'center', alignItems: 'center' }}>
+        <button onClick={prev} className={styles.carouselButton}>‹</button>
+        <div
+          className={styles.card}
+          key={tokens[index].id}
+          style={{ cursor: 'pointer', maxWidth: '500px', margin: '0 auto' }}
+        >
+          <img
+            src={tokens[index].meta.image}
+            alt={tokens[index].meta.name}
+            className={styles.cardImage}
+            style={{ width: '100%', height: 'auto', borderRadius: '1rem' }}
+          />
+          <h3 className={styles.cardTitle}>{tokens[index].meta.name}</h3>
+          <p className={styles.cardOwner}>Token #{tokens[index].id}</p>
+          {tokens[index].meta.description && (
+            <p className={styles.cardDescription}>{tokens[index].meta.description}</p>
+          )}
+          {Array.isArray(tokens[index].meta.attributes) && (
+            <ul>
+              {tokens[index].meta.attributes.map(attr => (
+                <li key={attr.trait_type}>
+                  <strong>{attr.trait_type}:</strong> {attr.value}
+                </li>
+              ))}
+            </ul>
+          )}
+          <p>
+            <a href={EXPLORER_URL} target="_blank" rel="noopener noreferrer" className={styles.cardLink}>
+              View on Explorer
+            </a>
+          </p>
+        </div>
+        <button onClick={next} className={styles.carouselButton}>›</button>
+      </div>
+      <a href="/" className={styles.homeButton}>Return Home</a>
+    </section>
+  );
+}
+

--- a/pages/kame.tsx
+++ b/pages/kame.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import KameGallery from '../components/KameGallery';
+import styles from '../styles/kamestyle.module.css';
+
+export default function KamePage() {
+  return (
+    <main className={styles.page}>
+      <KameGallery />
+    </main>
+  );
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ import TagPage from "./pages/TagPage";
 import CategoryPage from "./pages/CategoryPage";
 import ProjectPage from "./pages/projects/[slug].tsx";
 import FlameCoinPage from "../pages/flamecoin";
+import KamePage from "../pages/kame";
 import FounderPage from "./pages/founder";
 
 export default function App() {
@@ -27,6 +28,7 @@ export default function App() {
         <Route path="/category/:category" element={<CategoryPage />} />
         <Route path="/projects/:slug" element={<ProjectPage />} />
         <Route path="/flamecoin" element={<FlameCoinPage />} />
+        <Route path="/kame" element={<KamePage />} />
         <Route path="/founder" element={<FounderPage />} />
       </Routes>
     </HashRouter>

--- a/styles/kamestyle.module.css
+++ b/styles/kamestyle.module.css
@@ -1,0 +1,74 @@
+.page {
+  min-height: 100vh;
+  background-color: #0c0c0c;
+  color: #f3f4f6;
+  font-family: sans-serif;
+}
+.section {
+  padding: 2rem 1rem;
+  max-width: 800px;
+  margin: 0 auto;
+}
+.card {
+  background: rgba(255,255,255,0.1);
+  padding: 1.5rem;
+  border-radius: 0.75rem;
+  text-align: center;
+}
+.cardImage {
+  width: 200px;
+  height: auto;
+  border-radius: 0.5rem;
+  margin-bottom: 1rem;
+}
+.cardTitle {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+.cardOwner {
+  margin-bottom: 0.5rem;
+}
+.cardDescription {
+  margin-bottom: 0.5rem;
+}
+.cardLink {
+  color: #3b82f6;
+  text-decoration: underline;
+}
+.gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+.homeButton {
+  display: inline-block;
+  margin-top: 1.5rem;
+  padding: 0.75rem 1.5rem;
+  background: #ff5e00;
+  color: #fff;
+  border: none;
+  border-radius: 0.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background 0.2s;
+  cursor: pointer;
+}
+.homeButton:hover {
+  background: #ff7f32;
+}
+.carousel {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+}
+.carouselButton {
+  background: none;
+  border: none;
+  color: #f3f4f6;
+  font-size: 2rem;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- add a `KameGallery` component that fetches token transfers via RPC and reads IPFS metadata
- style Kame gallery with a new CSS module
- expose a simple `/kame` page that renders the gallery
- register the new route in `App.jsx`

## Testing
- `npm test` *(fails: Neither apiKey nor config.authenticator provided)*

------
https://chatgpt.com/codex/tasks/task_e_687e4c5903b8832e921827c062a676bd