### PR TITLE
Remove mint link and restore blog link

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -51,9 +51,9 @@ export default function Navbar() {
               </Link>
             </li>
             <li>
-              <a href="/mint.html" className="hover:text-blue-600 transition" onClick={() => setMobileOpen(false)}>
-                Mint
-              </a>
+              <Link to="/blog" className="hover:text-blue-600 transition" onClick={() => setMobileOpen(false)}>
+                Blog
+              </Link>
             </li>
           </ul>
           <ThemeToggle />


### PR DESCRIPTION
## Summary
- update navigation bar to remove Mint link
- add Blog link so users can access blog posts

## Testing
- `npm test` *(fails: Neither apiKey nor config.authenticator provided)*

------
https://chatgpt.com/codex/tasks/task_e_6887b67e1efc832eaaaf4866fd83c8e9